### PR TITLE
fix: re-signin token error

### DIFF
--- a/Backend/main.py
+++ b/Backend/main.py
@@ -13,9 +13,17 @@ from model.after_image import AfterImage
 load_dotenv()
 
 
-def is_valid_input(input_string):
+def is_id_valid_input(input_string):
     """
-    특수문자(!, @, *, _)와 알파벳 대/소문자, 숫자만. 정규표현식으로 유효성 검사하는 함수
+    아이디는 특수문자(_)와 알파벳 대/소문자, 숫자만. 정규표현식으로 유효성 검사하는 함수
+    """
+    pattern = r'^[a-z0-9_]+$'
+    return re.match(pattern, input_string)
+
+
+def is_pw_valid_input(input_string):
+    """
+    비밀번호는 특수문자(!, @, *, _)와 알파벳 대/소문자, 숫자만. 정규표현식으로 유효성 검사하는 함수
     """
     pattern = r'^[a-zA-Z0-9!@*_]+$'
     return re.match(pattern, input_string)
@@ -60,11 +68,11 @@ def sign_up():
     if existing_user:
         return jsonify(message='이미 존재하는 아이디입니다.'), 400
 
-    if user_id is None or not is_valid_input(user_id):
-        return jsonify(message='아이디는 알파벳과 숫자, !, @, *, _만 허용됩니다.'), 422
+    if user_id is None or not is_id_valid_input(user_id):
+        return jsonify(message='아이디는 알파벳 소문자와 숫자, 특수문자 _만 허용됩니다.'), 422
 
-    if user_pw is None or not is_valid_input(user_pw):
-        return jsonify(message='비밀번호는 알파벳과 숫자, !, @, *, _만 허용됩니다.'), 422
+    if user_pw is None or not is_pw_valid_input(user_pw):
+        return jsonify(message='비밀번호는 알파벳 대소문자와 숫자, 특수문자 !, @, *, _만 허용됩니다.'), 422
 
     token = generate_token(user_id)
 
@@ -93,6 +101,9 @@ def sign_in():
     user = User.query.filter_by(user_id=user_id).first()
     if not user:
         return jsonify(message='아이디가 존재하지 않습니다.'), 404
+
+    if user.user_id != user_id:
+        return jsonify(message='아이디가 일치하지 않습니다.'), 401
 
     if user.user_pw != user_pw:
         return jsonify(message='비밀번호가 일치하지 않습니다.'), 401

--- a/Backend/model/user.py
+++ b/Backend/model/user.py
@@ -19,3 +19,4 @@ class User(db.Model):
         nullable=False
     )
     is_making = db.Column(Boolean, default=False, nullable=False)
+    token = db.Column(db.String(255), nullable=False)


### PR DESCRIPTION
fixed #15 

### 수정한 내용

- Nginx에서 이미지 1M 넘어가면 못 받는 현상 → 5MB로 늘려놓음
- 어플 삭제했다가 다시 깔았을 때 로그인 안되는 문제 → 기존 코드로는 어플 삭제 시 토큰이 클라이언트 단에서 휘발되어 있기 때문에 발생한 문제. 백엔드에서 방식 수정하고 에러 예외 처리 추가. 기존에는 회원가입할 때 토큰을 클라이언트에 넘겨줬지만 로그인할 때 넘겨주도록 변경.
- 회원가입할 때 Null로 가입한다거나 공백을 추가하지 못하도록 조건 설정 (영어, 숫자, 특수문자 일부 !, @, *, _)